### PR TITLE
 #11896   docs: fix broken contributing link in org profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,6 @@ The cBioPortal for Cancer Genomics provides visualization, analysis, and downloa
 
 If you would like to know how to setup a private instance of the portal and/or get set up for developing, see the [documentation](https://docs.cbioportal.org). For details on contributing code changes via pull requests, see our [Contributing document](https://github.com/cBioPortal/cbioportal/blob/master/CONTRIBUTING.md).
 
-
 If you are interested in coordinating the development of new features, please contact cbioportal@cbioportal.org or reach out on https://slack.cbioportal.org.
 
 ## 📘 Documentation

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,8 @@
 ## cBioPortal
 The cBioPortal for Cancer Genomics provides visualization, analysis, and download of large-scale cancer genomics data sets. For a short intro on cBioPortal, see [these introductory slides](https://docs.google.com/presentation/d/1hm0G77UklZnpQfFvywBfW2ZIsy8deKi5r1RfJarOPLg/edit?usp=sharing).
 
-If you would like to know how to setup a private instance of the portal and/or get set up for developing, see the [documentation](https://docs.cbioportal.org). For details on contributing code changes via pull requests, see our [Contributing document](CONTRIBUTING.md).
+If you would like to know how to setup a private instance of the portal and/or get set up for developing, see the [documentation](https://docs.cbioportal.org). For details on contributing code changes via pull requests, see our [Contributing document](https://github.com/cBioPortal/cbioportal/blob/master/CONTRIBUTING.md).
+
 
 If you are interested in coordinating the development of new features, please contact cbioportal@cbioportal.org or reach out on https://slack.cbioportal.org.
 


### PR DESCRIPTION
#11896
This PR fixes a 404 error on the organization profile page. The link to the contributing guidelines was using a relative path (CONTRIBUTING.md) which does not exist in the .github repository.

I have updated it to the absolute URL pointing to the main cbioportal/cbioportal repository to ensure users can correctly access the contribution guide.